### PR TITLE
Add LinkedIn and GitHub profile links to portfolio

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -18,13 +18,13 @@ const quickLinks = [
 const socialLinks = [
   {
     icon: Linkedin,
-    href: "#",
+    href: "https://www.linkedin.com/in/adityasirsalkar/",
     label: "LinkedIn",
     hoverColor: "hover:text-blue-600"
   },
   {
     icon: Github,
-    href: "#",
+    href: "https://github.com/AdityaSirsalkar001",
     label: "GitHub",
     hoverColor: "hover:text-gray-800 dark:hover:text-gray-200"
   },
@@ -77,7 +77,7 @@ export function Footer() {
                       className={`rounded-full transition-colors ${social.hoverColor}`}
                       asChild
                     >
-                      <a href={social.href} aria-label={social.label}>
+                      <a href={social.href} aria-label={social.label} target="_blank" rel="noopener noreferrer">
                         <Icon className="w-5 h-5" />
                       </a>
                     </Button>

--- a/components/sections/contact.tsx
+++ b/components/sections/contact.tsx
@@ -61,13 +61,13 @@ const socialLinks = [
   {
     icon: Linkedin,
     label: "LinkedIn",
-    href: "#",
+    href: "https://www.linkedin.com/in/adityasirsalkar/",
     description: "Connect professionally"
   },
   {
     icon: Github,
-    label: "GitHub", 
-    href: "#",
+    label: "GitHub",
+    href: "https://github.com/AdityaSirsalkar001",
     description: "View my repositories"
   }
 ]
@@ -218,7 +218,7 @@ export function ContactSection() {
                             className="rounded-full"
                             asChild
                           >
-                            <a href={social.href} aria-label={social.label}>
+                            <a href={social.href} aria-label={social.label} target="_blank" rel="noopener noreferrer">
                               <Icon className="w-5 h-5" />
                             </a>
                           </Button>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -261,12 +261,12 @@ export function HeroSection() {
             className="flex items-center justify-center gap-4 mb-12"
           >
             <Button variant="ghost" size="icon" className="rounded-full" asChild>
-              <a href="#" aria-label="LinkedIn Profile">
+              <a href="https://www.linkedin.com/in/adityasirsalkar/" aria-label="LinkedIn Profile" target="_blank" rel="noopener noreferrer">
                 <Linkedin className="w-5 h-5" />
               </a>
             </Button>
             <Button variant="ghost" size="icon" className="rounded-full" asChild>
-              <a href="#" aria-label="GitHub Profile">
+              <a href="https://github.com/AdityaSirsalkar001" aria-label="GitHub Profile" target="_blank" rel="noopener noreferrer">
                 <Github className="w-5 h-5" />
               </a>
             </Button>


### PR DESCRIPTION
## Purpose
The user requested to add their LinkedIn and GitHub profile links to the portfolio website. The existing social media links were placeholder links ("#") that weren't functional, preventing users from accessing the actual profiles.

## Code changes
- **Updated social links**: Replaced placeholder "#" hrefs with actual LinkedIn and GitHub URLs across three components:
  - Footer component: Added LinkedIn (https://www.linkedin.com/in/adityasirsalkar/) and GitHub (https://github.com/AdityaSirsalkar001) links
  - Contact section: Updated the same social links in the contact area
  - Hero section: Added functional social links to the hero section
- **Enhanced accessibility**: Added `target="_blank"` and `rel="noopener noreferrer"` attributes to all social links for secure external navigation
- **Fixed formatting**: Minor whitespace cleanup in the contact component

The changes ensure all social media icons throughout the portfolio now properly link to the user's actual profiles and open in new tabs for better user experience.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/135bcc296c6b4f7187f9901a3f966f43/glow-nest)

👀 [Preview Link](https://135bcc296c6b4f7187f9901a3f966f43-glow-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>135bcc296c6b4f7187f9901a3f966f43</projectId>-->
<!--<branchName>glow-nest</branchName>-->